### PR TITLE
Add MCP server integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,19 @@ python scripts/one_day_pred.py --config CONFIG_NAME --ckpt_path PATH_TO_CHECKPOI
 If you don't provide a value for `DATE`, the code automatically predicts one day after the last day that is in the file.
 
 <!-- ### Trading Suggestion -->
- 
+
+### MCP Server
+
+An MCP server exposing training, evaluation and prediction tools is provided in
+[`mcp_server.py`](./mcp_server.py). Run it with:
+
+```
+python mcp_server.py
+```
+
+For client configuration instructions see
+[`docs/mcp_server_config.md`](docs/mcp_server_config.md).
+
 
 ## 📈 Results
 

--- a/docs/mcp_server_config.md
+++ b/docs/mcp_server_config.md
@@ -1,0 +1,43 @@
+# MCP Server Configuration
+
+This document shows how to connect VS Code or other MCP-compatible clients to the
+`CryptoMamba` server implemented in `mcp_server.py`.
+
+## Example `mcp.json`
+
+Place a file named `mcp.json` in your project or workspace and add an entry for
+this server. When the MCP extension starts, it will read this configuration and
+launch the server.
+
+```json
+{
+  "servers": {
+    "crypto-mamba": {
+      "type": "streamable-http",
+      "command": "python",
+      "args": ["mcp_server.py"],
+      "url": "http://localhost:8000"
+    }
+  }
+}
+```
+
+### Prompted Inputs
+
+If your tools require API keys or other credentials, you can add them under
+`inputs` to have VS Code securely prompt for them on first start.
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "perplexity-key",
+      "description": "Perplexity API Key",
+      "password": true
+    }
+  ]
+}
+```
+
+Combine these sections as needed to connect multiple servers.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,170 @@
+import os
+import sys
+import uuid
+import threading
+from typing import List, Dict, Any
+
+from pydantic import BaseModel
+from mcp.server import FastMCP
+
+# add project root to path
+ROOT = os.path.dirname(os.path.abspath(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from scripts import training, evaluation, one_day_pred, simulate_trade
+
+# initialize MCP server
+app = FastMCP("CryptoMamba MCP Server")
+
+# simple task registry
+TASKS: Dict[str, Dict[str, Any]] = {}
+
+class TrainRequest(BaseModel):
+    config: str
+    logger_type: str = "tb"
+    accelerator: str = "gpu"
+    devices: int = 1
+    batch_size: int = 32
+    num_workers: int = 4
+    seed: int = 23
+    save_checkpoints: bool = False
+    use_volume: bool | None = None
+    max_epochs: int | None = None
+
+class EvalRequest(BaseModel):
+    config: str
+    ckpt_path: str
+    batch_size: int = 32
+    num_workers: int = 4
+    use_volume: bool | None = None
+
+class PredictRequest(BaseModel):
+    config: str
+    ckpt_path: str
+    data_path: str = "data/one_day_pred.csv"
+    date: str | None = None
+    risk: int = 2
+    use_volume: bool = False
+
+class TradeRequest(BaseModel):
+    config: str
+    ckpt_path: str | None = None
+    split: str = "test"
+    trade_mode: str = "smart"
+    batch_size: int = 32
+    num_workers: int = 4
+    balance: float = 100
+    risk: float = 2
+
+
+def run_training_async(task_id: str, req: TrainRequest):
+    TASKS[task_id]["status"] = "running"
+    try:
+        args = [
+            "--config", req.config,
+            "--logger_type", req.logger_type,
+            "--accelerator", req.accelerator,
+            "--devices", str(req.devices),
+            "--batch_size", str(req.batch_size),
+            "--num_workers", str(req.num_workers),
+            "--seed", str(req.seed),
+        ]
+        if req.save_checkpoints:
+            args.append("--save_checkpoints")
+        if req.use_volume:
+            args.append("--use_volume")
+        if req.max_epochs is not None:
+            args.extend(["--max_epochs", str(req.max_epochs)])
+        training.main(args)
+        TASKS[task_id]["status"] = "completed"
+    except Exception as e:
+        TASKS[task_id]["status"] = f"failed: {e}"
+
+
+def run_evaluation(req: EvalRequest) -> Dict[str, Any]:
+    args = [
+        "--config", req.config,
+        "--ckpt_path", req.ckpt_path,
+        "--batch_size", str(req.batch_size),
+        "--num_workers", str(req.num_workers),
+    ]
+    if req.use_volume:
+        args.append("--use_volume")
+    return evaluation.main(args)
+
+
+def run_prediction(req: PredictRequest) -> Dict[str, Any]:
+    args = [
+        "--config", req.config,
+        "--ckpt_path", req.ckpt_path,
+        "--data_path", req.data_path,
+        "--risk", str(req.risk),
+    ]
+    if req.date:
+        args.extend(["--date", req.date])
+    if req.use_volume:
+        args.append("--use_volume")
+    return one_day_pred.main(args)
+
+
+def run_trade(req: TradeRequest) -> Dict[str, Any]:
+    args = [
+        "--config", req.config,
+        "--split", req.split,
+        "--trade_mode", req.trade_mode,
+        "--batch_size", str(req.batch_size),
+        "--num_workers", str(req.num_workers),
+        "--balance", str(req.balance),
+        "--risk", str(req.risk),
+    ]
+    if req.ckpt_path:
+        args.extend(["--ckpt_path", req.ckpt_path])
+    return simulate_trade.main(args)
+
+
+@app.tool(description="List available training configs")
+def list_training_configs() -> List[str]:
+    """Return available config names under configs/training."""
+    path = os.path.join(ROOT, "configs", "training")
+    return [x.replace(".yaml", "") for x in os.listdir(path) if x.endswith(".yaml")]
+
+
+@app.tool(description="Start a training job")
+def start_training(req: TrainRequest) -> Dict[str, str]:
+    """Launch training in a background thread and return a task id."""
+    task_id = str(uuid.uuid4())
+    TASKS[task_id] = {"status": "pending"}
+    thread = threading.Thread(target=run_training_async, args=(task_id, req), daemon=True)
+    TASKS[task_id]["thread"] = thread
+    thread.start()
+    return {"task_id": task_id}
+
+
+@app.tool(description="Get status of a training task")
+def task_status(task_id: str) -> Dict[str, Any]:
+    """Return the status dictionary for a given task id."""
+    return TASKS.get(task_id, {"status": "unknown"})
+
+
+@app.tool(description="Evaluate a model checkpoint")
+def evaluate_model(req: EvalRequest) -> Dict[str, Any]:
+    """Run evaluation for the provided checkpoint."""
+    return run_evaluation(req)
+
+
+@app.tool(description="Predict the next day price")
+def predict_next_day(req: PredictRequest) -> Dict[str, Any]:
+    """Run one-day prediction using a trained model."""
+    return run_prediction(req)
+
+
+@app.tool(description="Run a trading simulation")
+def simulate(req: TradeRequest) -> Dict[str, Any]:
+    """Simulate trading based on model predictions."""
+    return run_trade(req)
+
+
+if __name__ == "__main__":
+    app.run(transport="streamable-http")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ pandas
 einops
 tensorboard
 mamba-ssm[causal-conv1d]
+fastapi
+uvicorn[standard]
+mcp

--- a/scripts/evaluation.py
+++ b/scripts/evaluation.py
@@ -27,7 +27,7 @@ palette = sns.color_palette('muted')
 
 ROOT = io_tools.get_root(__file__, num_returns=2)
 
-def get_args():
+def get_args(argv=None):
     parser = ArgumentParser()
     parser.add_argument(
         "--logdir",
@@ -94,7 +94,7 @@ def get_args():
         help="batch_size",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     return args
 
 def print_and_write(file, txt, add_new_line=True):
@@ -167,9 +167,8 @@ def run_model(model, dataloader, factors=None):
 
 
 
-if __name__ == "__main__":
-
-    args = get_args()
+def main(argv=None):
+    args = get_args(argv)
     pl.seed_everything(args.seed)
     logdir = args.logdir
 
@@ -234,4 +233,12 @@ if __name__ == "__main__":
     ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, pos: '{:,.0f}K'.format(x/1000)))
     plt.savefig(plot_path, dpi=300, bbox_inches='tight')
     f.close()
+    return {
+        "plot_path": plot_path,
+        "metrics_file": f.name,
+    }
+
+
+if __name__ == "__main__":
+    main()
 

--- a/scripts/one_day_pred.py
+++ b/scripts/one_day_pred.py
@@ -19,7 +19,7 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 
 ROOT = io_tools.get_root(__file__, num_returns=2)
 
-def get_args():
+def get_args(argv=None):
     parser = ArgumentParser()
     parser.add_argument(
         "--accelerator",
@@ -72,7 +72,7 @@ def get_args():
         type=int,
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     return args
 
 def print_and_write(file, txt, add_new_line=True):
@@ -133,9 +133,8 @@ def run_model(model, dataloader):
 
 
 
-if __name__ == "__main__":
-
-    args = get_args()
+def main(argv=None):
+    args = get_args(argv)
 
     config = io_tools.load_config_from_yaml(f'{ROOT}/configs/training/{args.config}.yaml')
 
@@ -227,6 +226,15 @@ if __name__ == "__main__":
         print_and_write(txt_file, f'Vanilla trade: sell')
     else:
         print_and_write(txt_file, f'Vanilla trade: -')
+    return {
+        "prediction": pred,
+        "today": today,
+        "txt_file": txt_file.name,
+    }
+
+
+if __name__ == "__main__":
+    main()
 
     
 

--- a/scripts/simulate_trade.py
+++ b/scripts/simulate_trade.py
@@ -29,7 +29,7 @@ LABEL_DICT = {
     'itransformer': 'iTransformer',
 }
 
-def get_args():
+def get_args(argv=None):
     parser = ArgumentParser()
     parser.add_argument(
         "--accelerator",
@@ -113,7 +113,7 @@ def get_args():
         choices={'smart', 'smart_w_short', 'vanilla', 'no_strategy'},
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     return args
 
 def load_model(config, ckpt_path, config_name=None):
@@ -176,8 +176,8 @@ def run_model(model, dataloader, factors=None):
     return timetamps, targets, preds
 
 
-if __name__ == '__main__':
-    args = get_args()
+def main(argv=None):
+    args = get_args(argv)
     init_dir_flag = False
     colors = ['darkblue', 'yellowgreen', 'crimson', 'darkviolet', 'orange', 'magenta']
     if args.config == 'all':
@@ -275,3 +275,8 @@ if __name__ == '__main__':
     plt.xlabel('Date')
     plt.legend(loc='upper left')
     plt.savefig(plot_path, dpi=300, bbox_inches='tight')
+    return {"plot_path": plot_path}
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -16,7 +16,7 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 
 ROOT = io_tools.get_root(__file__, num_returns=2)
 
-def get_args():
+def get_args(argv=None):
     parser = ArgumentParser()
     parser.add_argument(
         "--logdir",
@@ -93,7 +93,7 @@ def get_args():
         default=200,
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     return args
 
 
@@ -127,9 +127,8 @@ def load_model(config, logger_type):
     return model, normalize
 
 
-if __name__ == "__main__":
-
-    args = get_args()
+def main(argv=None):
+    args = get_args(argv)
     pl.seed_everything(args.seed)
     logdir = args.logdir
 
@@ -198,3 +197,7 @@ if __name__ == "__main__":
     trainer.fit(model, datamodule=data_module)
     if args.save_checkpoints:
         trainer.test(model, datamodule=data_module, ckpt_path=checkpoint_callback.best_model_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `mcp_server.py` with FastMCP endpoints for training, evaluation, prediction and trading simulation
- document VSCode MCP configuration in `docs/mcp_server_config.md`
- mention running the MCP server in the README
- fix missing newline at end of `simulate_trade.py`

## Testing
- `python -m py_compile mcp_server.py scripts/training.py scripts/evaluation.py scripts/simulate_trade.py scripts/one_day_pred.py`


------
https://chatgpt.com/codex/tasks/task_e_68413bac04788331b236fca1f9168d11